### PR TITLE
maxshards + completeshard

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -30,7 +30,7 @@ module.exports = function(dyno, kinesis, config) {
     dyno.query({type:{EQ:'shard'}}, function(err, shardsFromDynamo) {
       if(err) return cb(err);
       for(var s=0; s < shardsFromDynamo.length; s++) {
-        if ((shardsFromDynamo[s].status === 'available') || (shardsFromDynamo[s].expiresAt < +new Date())) {
+        if ((shardsFromDynamo[s].status === 'available') || ((shardsFromDynamo[s].expiresAt < +new Date()) && (shardsFromDynamo[s].status !== 'complete'))) {
           return cb(null, shardsFromDynamo[s]);
         }
       }
@@ -61,6 +61,20 @@ module.exports = function(dyno, kinesis, config) {
     dyno.updateItem(
       {type:'shard', id: s.id},
       {add: {counter: 1}, put: {expiresAt: +new Date() + (1000*20), updated: +new Date()}},
+      {
+        conidtionalOperator: 'AND',
+        expected: {
+          expiresAt: {GE: +new Date()},
+          status: {EQ: 'leased'},
+          instance: {EQ: config.instanceId}
+        }
+      }, cb);
+  };
+
+  db.shardComplete = function(s, cb) {
+    dyno.updateItem(
+      {type:'shard', id: s.id},
+      {put: {status: 'complete'}},
       {
         conidtionalOperator: 'AND',
         expected: {

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -10,6 +10,7 @@ module.exports = function(config, kinesis) {
 
   config.table = config.table || 'kinesis-client-library-'+hat(6);
   config.instanceId = [os.hostname(), process.pid, +new Date()].join('-');
+  config.maxShards = config.maxShards || 100;
 
   var dyno = Dyno({
     table: config.table,
@@ -28,7 +29,7 @@ module.exports = function(config, kinesis) {
 
 
   // make sure that our dynamo table exists.
-  dyno.createTable(table(config.table), function(err){
+  dyno.createTable(table(config.table), function(err) {
     if(err) throw err;
 
     var  q = queue(1);
@@ -44,7 +45,6 @@ module.exports = function(config, kinesis) {
   kcl.stop = function() {
     stop = true;
   };
-
 
   // figure out the shards that this instance is responsible for and the checkpoints of those shards
   function shards() {
@@ -84,6 +84,7 @@ module.exports = function(config, kinesis) {
     function needMore() {
       if (stop) return;
       howMany = Math.ceil(shardList.length / instanceList.length);
+      howMany = (howMany < config.maxShards ? howMany : config.maxShards);
       if (Object.keys(instanceShardList).length < howMany) {
         setTimeout(db.availableShard.bind(this, foundShardToLease), 2000).unref();
       } else {
@@ -111,6 +112,7 @@ module.exports = function(config, kinesis) {
         if(err) throw err;
 
         shard.iterator = resp.NextShardIterator;
+
         if(resp.Records.length > 0) {
           shard.sequenceNumber = resp.Records[resp.Records.length -1].SequenceNumber;
           config.processRecords.call(shard, resp.Records, processRecordsDone);
@@ -128,8 +130,15 @@ module.exports = function(config, kinesis) {
       }
     }
     function checkpointSaved(err, resp) {
-      if(err) throw err;
-      setImmediate(getRecords.bind(this, shard));
+      if (err) throw err;
+      if (shard.iterator === null) {
+        // we are done with this shard, its complete.  lets mark it as complete.
+        db.shardComplete(shard, function(err){
+          if (err) throw err;
+        });
+      } else {
+        setImmediate(getRecords.bind(this, shard));
+      }
     }
   }
 


### PR DESCRIPTION
adding better support for marking a shard as complete once a closed shard has been fully read.  when a shard is complete, next iterator is null, then we complete the shard, We only do this if the processRecords asked for a checkpoint, so we know the records have been processed

Also adds `config.maxShards` for max Shards per process. defaults to 100


cc @camilleanne 