### PR TITLE
fewer requests to describe stream

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -6,7 +6,7 @@ module.exports = function(dyno, kinesis, config) {
 
   db.updateShards = function(cb) {
     kinesis.describeStream({StreamName: config.streamName}, function(err, stream) {
-      if(err) throw err;
+      if (err) cb(err);
       var q = queue();
 
       stream.StreamDescription.Shards.forEach(function(shard) {
@@ -16,8 +16,6 @@ module.exports = function(dyno, kinesis, config) {
           { expected: {id: {NULL: []}}});
       });
 
-      // look at the list in dynamo, remove any that arent in stream description.
-      // maybe possible to do this when getRecords fails because the shard isnt there?
       q.awaitAll(function(err) {
         if(err && err.code !== 'ConditionalCheckFailedException') return cb(err);
         cb(null, stream.StreamDescription.Shards);

--- a/lib/db.js
+++ b/lib/db.js
@@ -26,6 +26,10 @@ module.exports = function(dyno, kinesis, config) {
     });
   };
 
+  db.getShardList = function(cb) {
+    dyno.query({type:{EQ:'shard'}}, cb);
+  };
+
   db.availableShard = function(cb) {
     dyno.query({type:{EQ:'shard'}}, function(err, shardsFromDynamo) {
       if(err) return cb(err);

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -63,6 +63,9 @@ module.exports = function(config, kinesis) {
     // calls to kinesis, and thus we get throttled less.
     if(instancePosition() < 3) {
       db.updateShards(function(err, updatedShards) {
+        if (err && err.code === 'LimitExceededException') {
+          return setTimeout(shards, 10000).unref();
+        }
         if (err) throw err;
         shardList = updatedShards;
         needMore();

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -45,17 +45,35 @@ module.exports = function(config, kinesis) {
     stop = true;
   };
 
+
+  function instancePosition() {
+    for (var i =0; i < instanceList.length; i++) {
+      if (instanceList.id == config.instanceId) return i;
+    }
+    return -1;
+  }
+
   // figure out the shards that this instance is responsible for and the checkpoints of those shards
   function shards() {
     if (stop) return;
 
     var howMany = 0;
 
-    db.updateShards(function(err, updatedShards) {
-      if (err) throw err;
-      shardList = updatedShards;
-      needMore();
-    });
+    // only have the top few instances update the list of shards.  This reduce the number of
+    // calls to kinesis, and thus we get throttled less.
+    if(instancePosition() < 3) {
+      db.updateShards(function(err, updatedShards) {
+        if (err) throw err;
+        shardList = updatedShards;
+        needMore();
+      });
+    } else {
+      db.getShardList(function(err, updatedShards){
+        if (err) throw err;
+        shardList = updatedShards;
+        needMore();
+      });
+    }
 
     function foundShardToLease(err, shard) {
       if (err) throw err;
@@ -66,8 +84,7 @@ module.exports = function(config, kinesis) {
     function checkDone(err, shard) {
       if (err && err.code === 'ConditionalCheckFailedException') {
         // attempted to lease a shard that was already leased.  Lets try again.
-        console.log(err);
-        return setTimeout(db.availableShard.bind(this,foundShardToLease), 1000).unref();
+        return setTimeout(db.availableShard.bind(this,foundShardToLease), 5000).unref();
       } else if (err) {
         throw err;
       }


### PR DESCRIPTION
Have a subset of the processes track the state of the kinesis stream, reducing requests to kinesis and throttling errors