### PR TITLE
Do not require configuring cloudwatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ module.exports = function(config) {
   if ((config.cloudwatchNamespace && !config.cloudwatchStackname) ||
     (!config.cloudwatchNamespace && config.cloudwatchStackname)) throw new Error('both cloudwatchNamespace and cloudwatchStackname must be configured');
 
-
   config.maxProcessTime = config.maxProcessTime || 3e5;
 
   var kinesisOpts = {

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -11,8 +11,10 @@ module.exports = function(config, kinesis) {
   config.instanceId = [os.hostname(), process.pid, +new Date()].join('-');
   config.maxShards = config.maxShards || 10;
 
-  var cw = config.cloudwatch || new AWS.CloudWatch({region: config.region});
-  var throttledPutToCloudwatch = _.throttle(putToCloudwatch, 30000);
+  if (config.cloudwatchNamespace) {
+    var cw = config.cloudwatch || new AWS.CloudWatch({region: config.region});
+    var throttledPutToCloudwatch = _.throttle(putToCloudwatch, 30000);
+  }
 
   var dyno = Dyno({
     table: config.table,
@@ -132,7 +134,10 @@ module.exports = function(config, kinesis) {
     kinesis.getRecords(
       { ShardIterator: shard.iterator, Limit: 10000 },
       function(err, resp) {
-        if (resp.Records && resp.Records[0] && resp.Records[0].ApproximateArrivalTimestamp) {
+        if (config.cloudwatchNamespace &&
+          resp.Records &&
+          resp.Records[0] &&
+          resp.Records[0].ApproximateArrivalTimestamp) {
           throttledPutToCloudwatch('ShardIteratorAgeInMs', (+new Date()) - resp.Records[0].ApproximateArrivalTimestamp, 'Milliseconds', shard.id);
         }
 

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -142,6 +142,9 @@ test('start 2nd kcl', function(t) {
       shardIteratorType: 'TRIM_HORIZON',
       streamName: 'teststream',
       table: kine.config.table,
+      cloudwatchNamespace: null,
+      cloudwatchStackname: null,
+      cloudwatch: null,
       init: function(done) {
         console.log('init');
         done();


### PR DESCRIPTION
Whoops -- test didn't quite reset the cloudwatch options so configuring cloudwatch was required :(

This clarifies the test and doesn't attempt to put metrics to Cloudwatch unless it's been configured.

cc @mick @willwhite 