### PR TITLE
fix typo, fixes #23

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -64,7 +64,7 @@ module.exports = function(dyno, kinesis, config) {
       {type:'shard', id: s.id},
       {add: {counter: 1}, put: {expiresAt: +new Date() + config._leaseTimeout, updated: +new Date()}},
       {
-        conidtionalOperator: 'AND',
+        conditionalOperator: 'AND',
         expected: {
           expiresAt: {GE: +new Date()},
           status: {EQ: 'leased'},
@@ -78,7 +78,7 @@ module.exports = function(dyno, kinesis, config) {
       {type:'shard', id: s.id},
       {put: {status: 'complete'}},
       {
-        conidtionalOperator: 'AND',
+        conditionalOperator: 'AND',
         expected: {
           expiresAt: {GE: +new Date()},
           status: {EQ: 'leased'},


### PR DESCRIPTION
@puffnfresh Thanks for pointing out #23 

Good thing is that is the default operator. [From dynamo docs](http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-ConditionalOperator):

> If you omit ConditionalOperator, then AND is the default.


