### PR TITLE
save start and end hashkey to KCL table

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@ Features:
 ```js
 var Kine = require('kine');
 
-kine2 = Kine({
+var kcl = Kine({
   region: 'us-east-1',
   streamName: 'teststream',
   shardIteratorType: 'TRIM_HORIZON',
@@ -40,4 +40,33 @@ kine2 = Kine({
 });
 
 
+```
+
+##### kcl.stop
+
+A kine instance can be halted using `stop`. This will cause any future events to bail out and
+remove internal timers
+
+```js
+var Kine = require('kine');
+
+var kcl = Kine(/* config */);
+
+kcl.stop();
+```
+
+##### kcl.instanceInfo
+
+An instance can be queried by record Partition Key. This allows applications to locate which
+shard and instance are responsible for particular records in the stream.
+
+```js
+var Kine = require('kine');
+
+var kcl = Kine(/* config */);
+
+kcl.instanceInfo('0230102', function (err, info) {
+  // info contains shardId, instance, hashKeyStart and hashKeyEnd
+  // for the shard that contains records with partition key '0230102'
+});
 ```

--- a/lib/db.js
+++ b/lib/db.js
@@ -12,7 +12,15 @@ module.exports = function(dyno, kinesis, config) {
       stream.StreamDescription.Shards.forEach(function(shard) {
         q.defer(dyno.updateItem,
           { type: 'shard', id: shard.ShardId},
-          { put: {status: 'available', updated: +new Date(), expiresAt: 0}},
+          {
+            put: {
+              status: 'available',
+              hashKeyStart: shard.HashKeyRange.StartingHashKey,
+              hashKeyEnd: shard.HashKeyRange.EndingHashKey,
+              updated: +new Date(),
+              expiresAt: 0
+            }
+          },
           { expected: {id: {NULL: []}}});
       });
 

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -5,6 +5,8 @@ var queue = require('queue-async');
 var _ = require('lodash');
 var AWS = require('aws-sdk');
 var DB = require('./db');
+var BN = require('bignumber.js');
+var crypto = require('crypto');
 
 module.exports = function(config, kinesis) {
 
@@ -53,6 +55,27 @@ module.exports = function(config, kinesis) {
     stop = true;
   };
 
+  kcl.instanceInfo = function (partitionKey, callback) {
+    var md5 = crypto.createHash('md5').update(partitionKey).digest('hex');
+    var hashKey = new BN(md5, 16);
+
+    db.getShardList(function (err, shards) {
+      if (err) return callback(err);
+
+      for (var s = 0; s < shards.length; s++) {
+        if (hashKey.cmp(shards[s].hashKeyStart) >= 0 && hashKey.cmp(shards[s].hashKeyEnd) <= 0) {
+          return callback(null, {
+            instance: shards[s].instance,
+            shardId: shards[s].id,
+            hashKeyStart: shards[s].hashKeyStart,
+            hashKeyEnd: shards[s].hashKeyEnd
+          });
+        }
+      }
+
+      return callback(new Error('No shard found for ' + partitionKey));
+    });
+  };
 
   function instancePosition() {
     for (var i =0; i < instanceList.length; i++) {

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -8,7 +8,7 @@ var DB = require('./db');
 
 module.exports = function(config, kinesis) {
 
-  config.instanceId = [os.hostname(), process.pid, +new Date()].join('-');
+  config.instanceId = config.instanceId || [os.hostname(), process.pid, +new Date()].join('-');
   config.maxShards = config.maxShards || 10;
   config.Limit = config.limit || 10000;
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "aws-sdk": "^2.1.24",
+    "bignumber.js": "^2.4.0",
     "dynalite": "^0.11.0",
     "dyno": "^0.11.3",
     "lodash": "^3.7.0",

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -171,4 +171,15 @@ test('stop kcl2', function(t){
   setTimeout(t.end, 6000);
 });
 
+test('query instanceInfo', function (t) {
+  kine.instanceInfo('a', function (err, info) {
+    t.error(err, 'no error querying instance info');
+    t.equal(info.instance, kine.config.instanceId, 'finds the instance');
+    t.ok(info.hashKeyStart, 'info has hashKeyStart');
+    t.ok(info.hashKeyEnd, 'info has hashKeyEnd');
+    t.ok(info.shardId, 'info has shardId');
+    t.end();
+  });
+});
+
 test('teardown', util.teardown);

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -107,6 +107,8 @@ test('kcl - checkpointed', function(t){
       shards.forEach(function(s) {
         t.equal(s.status, 'leased', 'leased');
         t.equal(s.instance, kine.config.instanceId, 'this instance leased');
+        t.ok(s.hashKeyStart);
+        t.ok(s.hashKeyEnd);
       });
 
       var checkpointed = _(shards).filter(function(s){ return !!s.checkpoint;}).value();


### PR DESCRIPTION
when shards are described, copy the StartingHashKey and EndingHashKey so that applications can look up which shard / instance is processing data for specific partition keys

also adds support for custom `instanceId` to be set in config.

cc @mick 