### PR TITLE
retry parse errors from incomplete payloads

### DIFF
--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -159,7 +159,8 @@ module.exports = function(config, kinesis) {
     kinesis.getRecords(
       { ShardIterator: shard.iterator, Limit: config.limit },
       function(err, resp) {
-        if(err) throw err;
+        if (err && err.code === 'SyntaxError') return setTimeout(getRecords.bind(this, shard), 100);
+        if (err) throw err;
 
         if (config.cloudwatchNamespace &&
           resp.Records &&


### PR DESCRIPTION
syntaxerror seem to be caused by incomplete http payloads. We should retry those not just fail