### PR TITLE
Avoid 'cannot read length of undefined' error

### DIFF
--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -173,7 +173,7 @@ module.exports = function(config, kinesis) {
         shard.iterator = resp.NextShardIterator;
         shard.lastGetRecords = +new Date();
 
-        if(resp.Records.length > 0) {
+        if(resp.Records && resp.Records.length > 0) {
           shard.sequenceNumber = resp.Records[resp.Records.length -1].SequenceNumber;
           config.processRecords.call(shard, resp.Records, processRecordsDone);
         } else {


### PR DESCRIPTION
This is more an issue than a PR, as I am not sure if the behavior I'm seeing is expected.

I sometimes run into this error:

```js
throw err;
^
TypeError: Cannot read property 'length' of undefined
at Response.<anonymous> (.../node_modules/kine/lib/kcl.js:175:24)
```
which causes my process to crash and container to restart.

Is it expected that `Records` will sometimes be undefined? If so the simple fix below makes sure we catch that case.

cc @mick 