### PR TITLE
Fix bug that marks shards as complete on invalid responses.

### DIFF
--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -163,6 +163,8 @@ module.exports = function(config, kinesis) {
         if (err && err.code === 'SyntaxError') return setTimeout(getRecords.bind(this, shard), 100);
         if (err) throw err;
 
+        if (!resp.Records) return setTimeout(getRecords.bind(this, shard), 100); // Invalid response: retry in 100ms
+
         if (config.cloudwatchNamespace &&
           resp.Records &&
           resp.Records[0] &&
@@ -173,7 +175,7 @@ module.exports = function(config, kinesis) {
         shard.iterator = resp.NextShardIterator;
         shard.lastGetRecords = +new Date();
 
-        if(resp.Records && resp.Records.length > 0) {
+        if(resp.Records.length > 0) {
           shard.sequenceNumber = resp.Records[resp.Records.length -1].SequenceNumber;
           config.processRecords.call(shard, resp.Records, processRecordsDone);
         } else {

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -163,8 +163,6 @@ module.exports = function(config, kinesis) {
         if (err && err.code === 'SyntaxError') return setTimeout(getRecords.bind(this, shard), 100);
         if (err) throw err;
 
-        if (!resp.Records) return setTimeout(getRecords.bind(this, shard), 100); // Invalid response: retry in 100ms
-
         if (config.cloudwatchNamespace &&
           resp.Records &&
           resp.Records[0] &&
@@ -175,11 +173,11 @@ module.exports = function(config, kinesis) {
         shard.iterator = resp.NextShardIterator;
         shard.lastGetRecords = +new Date();
 
-        if(resp.Records.length > 0) {
+        if(resp.Records && resp.Records.length > 0) {
           shard.sequenceNumber = resp.Records[resp.Records.length -1].SequenceNumber;
           config.processRecords.call(shard, resp.Records, processRecordsDone);
         } else {
-          if (!shard.iterator) {
+          if (shard.iterator === null) {
             db.shardComplete(shard, function(err){
               if (err) throw err;
             });
@@ -202,7 +200,7 @@ module.exports = function(config, kinesis) {
 
     function checkpointSaved(err) {
       if (err) throw err;
-      if (!shard.iterator) {
+      if (shard.iterator === null) {
         // we are done with this shard, its complete.  lets mark it as complete.
         db.shardComplete(shard, function(err){
           if (err) throw err;


### PR DESCRIPTION
This fixes a bug that happens with v2.5.3. 

This last patch added a small check to make sure the response from Kinesis had records before trying to read `resp.Records.length` ([here](https://github.com/mapbox/kine/blob/07eb9d87f6d087c830cb155178f7d669ba66a1c2/lib/kcl.js#L176)). 

But this happens when the whole response is invalid (probably because of networking issues). In that case all response properties will be `undefined`, so `resp. NextShardIterator` is undefined.

In 2.5.2,  we used to hit an error `Cannot read property 'length' of undefined`. Now we hit [that line](https://github.com/mapbox/kine/blob/07eb9d87f6d087c830cb155178f7d669ba66a1c2/lib/kcl.js#L180-L183) and mark the shard as complete.

The fix is to detect those invalid responses earlier and trigger a retry.

cc @mick @l-r 