### PR TITLE
shard.iterator should always be valid (string or null, not undefined).

### DIFF
--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -170,7 +170,8 @@ module.exports = function(config, kinesis) {
           throttledPutToCloudwatch('ShardIteratorAgeInMs', (+new Date()) - resp.Records[0].ApproximateArrivalTimestamp, 'Milliseconds', shard.id);
         }
 
-        shard.iterator = resp.NextShardIterator;
+        // malformed responses will have an undefined NextShardIterator. In that case, we keep the existing one.
+        shard.iterator = resp.NextShardIterator === undefined ? shard.iterator : resp.NextShardIterator;
         shard.lastGetRecords = +new Date();
 
         if(resp.Records && resp.Records.length > 0) {

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -22,6 +22,14 @@ var kinesis = new AWS.Kinesis(kinesisOptions);
 
 var kine;
 
+var dyno = Dyno({
+  endpoint: 'http://localhost:4567',
+  accessKeyId: 'fake',
+  secretAccessKey: 'fake',
+  region: 'us-east-1',
+  table: 'kine-kcl-test'
+});
+
 test('createStream', function(t) {
   kinesis.createStream({ShardCount:4, StreamName: 'teststream'}, function(err){
     t.error(err);
@@ -93,14 +101,6 @@ test('start kcl', function(t){
 test('kcl - checkpointed', function(t){
 
   // check if it got checkpointed in dynamo
-  var dyno = Dyno({
-    endpoint: 'http://localhost:4567',
-    accessKeyId: 'fake',
-    secretAccessKey: 'fake',
-    region: 'us-east-1',
-    table: kine.config.table
-  });
-
   function checkpointed() {
     dyno.query({KeyConditions:{type:{ComparisonOperator:'EQ',AttributeValueList: ['shard']}}}, function(err, response) {
       var shards = response.Items;
@@ -186,7 +186,7 @@ var kine3;
 var getRecords;
 test('start 3rd kcl', function(t) {
 
-  t.plan(5);
+  t.plan(8);
 
   kine3 = Kine(
     _.extend(kinesisOptions, {
@@ -206,28 +206,41 @@ test('start 3rd kcl', function(t) {
         t.equals(records.length, 1);
         t.equals(records[0].SequenceNumber, 1);
         done(null, true);
-        t.end();
+        setTimeout(t.end, 10000);
       }
     })
   );
   var i = 0;
   getRecords = kine3.kinesis.getRecords;
   kine3.kinesis.getRecords = function(options, callback) {
+    // we mock successive responses, iterating on i in 0..5
     if (i == 0) {
-      t.ok(true); // gets called
-      callback(null, {}); // empty response, retry
+      t.ok(true, 'gets called, return empty response (retry)');
+      callback(null, {});
     } else if (i == 1) {
-      t.ok(true); // gets called too
-      callback(null, {Records: []}); // invalid response (no shard iterator), retry
+      t.ok(true, 'gets called, return invalid response, no shard iterator (retry)');
+      callback(null, {Records: []});
     } else if (i == 2) {
-      t.ok(true); // gets called
-      callback(null, {Records: null, NextShardIterator: 'valid'}); // invalid response (no records), retry
-    } else { // one valid response
+      t.ok(true, 'gets called as well, respond with no records (retry)');
+      callback(null, {Records: null, NextShardIterator: 'valid'});
+    } else if (i == 3) {
+      t.ok(true, 'gets called, respond with an error (retry)');
+      var err = new Error('Failed parsing');
+      err.code = 'SyntaxError';
+      callback(err, null);
+    } else if (i == 4) {
+      t.ok(true, 'gets called, return valid response');
       callback(null, {
         NextShardIterator: 'valid',
         Records: [
           {SequenceNumber: 1}
         ]
+      });
+    } else if (i == 5) {
+      t.ok(true, 'gets called, return null as next shard iterator (close shard)');
+      callback(null, {
+        NextShardIterator: null,
+        Records: []
       });
     }
     i++;
@@ -239,6 +252,19 @@ test('stop kcl3', function(t){
   kine3.kinesis.getRecords = getRecords;
   kine3.stop();
   setTimeout(t.end, 6000);
+});
+
+test('kcl - closed shard', function(t){
+
+  function closedShard() {
+    dyno.query({KeyConditions:{type:{ComparisonOperator:'EQ',AttributeValueList: ['shard']}}}, function(err, response) {
+      var shards = response.Items;
+      t.equal(shards.length, 4);
+      t.equal(shards[2].status, 'complete');
+      t.end();
+    });
+  }
+  setTimeout(closedShard, 1000);
 });
 
 test('teardown', util.teardown);


### PR DESCRIPTION
#31 fixed the issue where shards would be incorrectly marked as complete when NexShardIterator was `undefined` in the response from kinesis.GetRecords.

But in that case the shard's iterator was set to `undefined`, causing the next call to be invalid. This PR fixes that.

We explicitly catch `undefined` NexShardIterator property to always keep a valid one in shard.iterator, i.e. `null` (shard can be closed) or a string.

As to the root cause of this, it seems like the callback is being called with `(null, null)` (no error and no data), which according to [the AWS SDK documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Kinesis.html#getRecords-property) should not happen. This PR makes sure we have a safeguard against that and retry with a valid payload when it happens.

cc @mick @l-r 