### PR TITLE
getRecords refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.10'
+- '4.4.3'
 sudo: false
 cache:
   directories:

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-#Kine
+# Kine
 
 Kine makes reading from an aws kinesis stream easy.
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var Kcl = require('./lib/kcl');
  * @param {function} options.init - function that is called when a new lease of a shard is started
  * @param {function} options.processRecords - function is that called when new records are fetches from the kinesis shard.
  * @param {string} [options.maxShards] - max number of shards to track per process. defaults to 10
- * @param {string} [options.limit] - limit used for requests to kinesis for the number of records.  This is a max, you might get few records on process recirds
+ * @param {string} [options.limit] - limit used for requests to kinesis for the number of records.  This is a max, you might get few records on process records
  * @param {string} [options.maxProcessTime] - max number of millseconds between getting records before considering a process a zombie . defaults to 300000 (5mins)
  * @param {string} [options.endpoint] - the kinesis endpoint url
  * @param {string} [options.dynamoEndpoint] - the dynamodb endpoint url
@@ -28,6 +28,7 @@ var Kcl = require('./lib/kcl');
  * @param {string} [options.sessionToken] - credentials for the client to utilize
  * @param {string} [options.cloudwatchNamespace] - namespace to use for custom cloudwatch reporting of shard ages. required if `cloudwatchStackname` is set
  * @param {string} [options.cloudwatchStackname] - stack name to use as a dimension on custom cloudwatch reporting of shard ages. required if `cloudwatchNamespace` is set
+ * @param {boolean} [options.verbose] - verbose output
 
  * @returns {client} a kine client
  * @example

--- a/index.js
+++ b/index.js
@@ -58,7 +58,11 @@ module.exports = function(config) {
     accessKeyId: config.accessKeyId,
     secretAccessKey: config.secretAccessKey,
     sessionToken: config.sessionToken,
-    maxRetries: 10
+    maxRetries: 10,
+    httpOptions: {
+      connectTimeout: 15000,
+      timeout: 10000
+    }
   };
 
   if (config.endpoint && config.endpoint !== '') kinesisOpts.endpoint = new AWS.Endpoint(config.endpoint);

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -185,7 +185,7 @@ module.exports = function(config, kinesis) {
       }
       if (err.code === 'ServiceUnavailable' || err.code === 'InternalFailure' || err.code === 'NetworkingError') {
         if (config.verbose) logger.info('[ getRecords ] Found serviceUnavailable', err);
-        return setTimeout(getRecords.bind(this, shard, attempts), 2000);
+        return setTimeout(getRecords.bind(this, shard, attempts), getBackoffWait(attempts));
       }
       throw new Error(err);
     });

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -145,8 +145,11 @@ module.exports = function(config, kinesis) {
     }
   }
 
-  function getRecords(shard) {
+  function getRecords(shard, attempts) {
+    attempts+=1;
     if (stop) return;
+    if(config.verbose) logger.info('[ getRecords ] attempt', attempts);
+    if(attempts >= 5) throw new Error('Too many getRecords attempts.');
 
     //make sure we are still responsible for this shard.
     if (!instanceShardList[shard.id]) return;
@@ -169,15 +172,15 @@ module.exports = function(config, kinesis) {
     req.on('error', function (err) {
       if (err.code === 'SyntaxError' || err.code === 'RequestAbortedError') {
         if (config.verbose) logger.info('[ getRecords ] Found SyntaxError', err);
-        return setTimeout(getRecords.bind(this, shard), 500);
+        return setTimeout(getRecords.bind(this, shard, attempts), 500);
       }
       if (err.code === 'ProvisionedThroughputExceededException') {
         if (config.verbose) logger.info('[ getRecords ] Found ProvisionedThroughputExceededException', err);
-        return setTimeout(getRecords.bind(this, shard), 1000);
+        return setTimeout(getRecords.bind(this, shard, attempts), 1000);
       }
       if (err.code === 'ServiceUnavailable' || err.code === 'InternalFailure' || err.code === 'NetworkingError') {
         if (config.verbose) logger.info('[ getRecords ] Found serviceUnavailable', err);
-        return setTimeout(getRecords.bind(this, shard), 2000);
+        return setTimeout(getRecords.bind(this, shard, attempts), 2000);
       }
       throw new Error(err);
     });
@@ -214,7 +217,7 @@ module.exports = function(config, kinesis) {
             if (err) throw err;
           });
         } else {
-          return setTimeout(getRecords.bind(this, shard), 2500).unref();
+          return setTimeout(getRecords.bind(this, shard, 0), 2500).unref();
         }
       }
     });
@@ -228,7 +231,7 @@ module.exports = function(config, kinesis) {
         // save checkpoint to dynamo.
         db.checkpoint(shard, checkpointSaved);
       } else {
-        setImmediate(getRecords.bind(this, shard));
+        setImmediate(getRecords.bind(this, shard, 0));
       }
     }
 
@@ -240,7 +243,7 @@ module.exports = function(config, kinesis) {
           if (err) throw err;
         });
       } else {
-        setImmediate(getRecords.bind(this, shard));
+        setImmediate(getRecords.bind(this, shard, 0));
       }
     }
   }
@@ -250,7 +253,7 @@ module.exports = function(config, kinesis) {
     shardIds.forEach(function(s) {
       if (!instanceShardList[s].getRecords) {
         config.init.call(instanceShardList[s], function() {
-          getRecords(instanceShardList[s]);
+          getRecords(instanceShardList[s], 0);
         });
         instanceShardList[s].getRecords = true;
       }

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -180,13 +180,16 @@ module.exports = function(config, kinesis) {
         return setTimeout(getRecords.bind(this, shard), 2000);
       }
       throw new Error(err);
-
     });
     req.on('extractData', function (response) {
       if (config.verbose) logger.info('[ getRecords ] extractData', response.data.Records.length, 'items');
     });
     req.on('retry', function (resp) {
       if (config.verbose) logger.info('[ getRecords retry ] retry count: ', resp.retryCount);
+      var nonRetryableErrors = ['ServiceUnavailable', 'InternalFailure', 'NetworkingError', 'ProvisionedThroughputExceededException', 'SyntaxError', 'RequestAbortedError'];
+      if (nonRetryableErrors.indexOf(resp.error.code) >= 0) {
+        resp.error.retryable = false; // disable retries entirely for these error codes since we are handling them ourselves
+      }
     });
     req.on('success', function (resp) {
       if (config.verbose) logger.info('[ getRecords ] success Found', resp.data.Records.length, 'items');

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -7,6 +7,7 @@ var AWS = require('aws-sdk');
 var DB = require('./db');
 var BN = require('bignumber.js');
 var crypto = require('crypto');
+var logger = require('fastlog')('kine');
 
 module.exports = function(config, kinesis) {
 
@@ -153,41 +154,70 @@ module.exports = function(config, kinesis) {
       return delete instanceShardList[shard.id];
     }
 
-    // expose the checkpoint function to the procerssRecords, so they can checkpoint
+    // expose the checkpoint function to the processRecords, so they can checkpoint
     // without requesting more records.
     shard.checkpointFunc = db.checkpoint.bind(null, shard);
 
-    kinesis.getRecords(
-      { ShardIterator: shard.iterator, Limit: config.limit },
-      function(err, resp) {
-        if (err && err.code === 'SyntaxError') return setTimeout(getRecords.bind(this, shard), 100);
-        if (err) throw err;
+    if (config.verbose) logger.info('[ getRecords ] params:', JSON.stringify({
+      ShardIterator: shard.iterator,
+      Limit: config.limit
+    }));
 
-        if (config.cloudwatchNamespace &&
-          resp.Records &&
-          resp.Records[0] &&
-          resp.Records[0].ApproximateArrivalTimestamp) {
-          throttledPutToCloudwatch('ShardIteratorAgeInMs', (+new Date()) - resp.Records[0].ApproximateArrivalTimestamp, 'Milliseconds', shard.id);
-        }
+    var req = kinesis.getRecords({ShardIterator: shard.iterator, Limit: config.limit});
+    var requestTimeOut = setTimeout(req.abort.bind(req), 5000);
 
-        // malformed responses will have an undefined NextShardIterator. In that case, we keep the existing one.
-        shard.iterator = resp.NextShardIterator === undefined ? shard.iterator : resp.NextShardIterator;
-        shard.lastGetRecords = +new Date();
+    req.on('error', function (err) {
+      if (err.code === 'SyntaxError' || err.code === 'RequestAbortedError') {
+        if (config.verbose) logger.info('[ getRecords ] Found SyntaxError', err);
+        return setTimeout(getRecords.bind(this, shard), 500);
+      }
+      if (err.code === 'ProvisionedThroughputExceededException') {
+        if (config.verbose) logger.info('[ getRecords ] Found ProvisionedThroughputExceededException', err);
+        return setTimeout(getRecords.bind(this, shard), 1000);
+      }
+      if (err.code === 'ServiceUnavailable' || err.code === 'InternalFailure' || err.code === 'NetworkingError') {
+        if (config.verbose) logger.info('[ getRecords ] Found serviceUnavailable', err);
+        return setTimeout(getRecords.bind(this, shard), 2000);
+      }
+      throw new Error(err);
 
-        if(resp.Records && resp.Records.length > 0) {
-          shard.sequenceNumber = resp.Records[resp.Records.length -1].SequenceNumber;
-          config.processRecords.call(shard, resp.Records, processRecordsDone);
+    });
+    req.on('extractData', function (response) {
+      if (config.verbose) logger.info('[ getRecords ] extractData', response.data.Records.length, 'items');
+    });
+    req.on('retry', function (resp) {
+      if (config.verbose) logger.info('[ getRecords retry ] retry count: ', resp.retryCount);
+    });
+    req.on('success', function (resp) {
+      if (config.verbose) logger.info('[ getRecords ] success Found', resp.data.Records.length, 'items');
+
+      if (config.cloudwatchNamespace &&
+        resp.Records &&
+        resp.Records[0] &&
+        resp.Records[0].ApproximateArrivalTimestamp) {
+        throttledPutToCloudwatch('ShardIteratorAgeInMs', (+new Date()) - resp.Records[0].ApproximateArrivalTimestamp, 'Milliseconds', shard.id);
+      }
+
+      // malformed responses will have an undefined NextShardIterator. In that case, we keep the existing one.
+      shard.iterator = resp.data.NextShardIterator === undefined ? shard.iterator : resp.data.NextShardIterator;
+      shard.lastGetRecords = +new Date();
+
+      if (resp.data.Records && resp.data.Records.length > 0) {
+        shard.sequenceNumber = resp.data.Records[resp.data.Records.length - 1].SequenceNumber;
+        config.processRecords.call(shard, resp.data.Records, processRecordsDone);
+      } else {
+        if (shard.iterator === null) {
+          db.shardComplete(shard, function (err) {
+            if (err) throw err;
+          });
         } else {
-          if (shard.iterator === null) {
-            db.shardComplete(shard, function(err){
-              if (err) throw err;
-            });
-          } else {
-            setTimeout(getRecords.bind(this, shard), 2500).unref();
-          }
+          return setTimeout(getRecords.bind(this, shard), 2500).unref();
         }
       }
-    );
+    });
+    req.send(function () {
+      clearTimeout(requestTimeOut);
+    });
 
     function processRecordsDone(err, checkpointShard) {
       if (err) throw err;

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -145,11 +145,16 @@ module.exports = function(config, kinesis) {
     }
   }
 
+  function getBackoffWait(attempts){
+    // random number between 500ms and 5000ms + (attempts*1000)ms
+    return Math.round(Math.random() * (5000 - 500) + 500 + (attempts*1000));
+  }
+
   function getRecords(shard, attempts) {
     attempts+=1;
     if (stop) return;
     if(config.verbose) logger.info('[ getRecords ] attempt', attempts);
-    if(attempts >= 5) throw new Error('Too many getRecords attempts.');
+    if(attempts >= 10) throw new Error('Too many getRecords attempts.');
 
     //make sure we are still responsible for this shard.
     if (!instanceShardList[shard.id]) return;
@@ -176,7 +181,7 @@ module.exports = function(config, kinesis) {
       }
       if (err.code === 'ProvisionedThroughputExceededException') {
         if (config.verbose) logger.info('[ getRecords ] Found ProvisionedThroughputExceededException', err);
-        return setTimeout(getRecords.bind(this, shard, attempts), 1000);
+        return setTimeout(getRecords.bind(this, shard, attempts), getBackoffWait(attempts));
       }
       if (err.code === 'ServiceUnavailable' || err.code === 'InternalFailure' || err.code === 'NetworkingError') {
         if (config.verbose) logger.info('[ getRecords ] Found serviceUnavailable', err);
@@ -186,6 +191,12 @@ module.exports = function(config, kinesis) {
     });
     req.on('extractData', function (response) {
       if (config.verbose) logger.info('[ getRecords ] extractData', response.data.Records.length, 'items');
+    });
+    req.on('extractError', function (response) {
+      if (config.verbose) logger.info('[ getRecords ] extractError', response);
+    });
+    req.on('httpError', function (response) {
+      if (config.verbose) logger.info('[ getRecords ] httpError', response);
     });
     req.on('retry', function (resp) {
       if (config.verbose) logger.info('[ getRecords retry ] retry count: ', resp.retryCount);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bignumber.js": "^2.4.0",
     "dynalite": "^0.11.0",
     "dyno": "^1.3.0",
+    "fastlog": "^1.1.0",
     "lodash": "^3.7.0",
     "queue-async": "^1.0.7"
   },

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -7,6 +7,7 @@ var Dyno = require('dyno');
 var _ = require('lodash');
 var sinon = require('sinon');
 var events = require('events');
+var DB = require('../lib/db.js');
 
 test('init', util.init);
 
@@ -84,7 +85,6 @@ test('start kcl', function(t){
         t.equal(records.length, 1, 'got record');
         t.equal(records[0].PartitionKey, 'a', 'has paritionKey');
         t.equal(records[0].Data.toString(), 'hello', 'has data');
-        sinon.assert.calledOnce(send);
         done(null, true);
         t.end();
       }
@@ -183,80 +183,8 @@ test('query instanceInfo', function (t) {
   });
 });
 
-var kine3;
-var getRecords;
-test('start 3rd kcl', function(t) {
-
-  t.plan(8);
-
-  kine3 = Kine(
-    _.extend(kinesisOptions, {
-      dynamoEndpoint: 'http://localhost:4567',
-      shardIteratorType: 'TRIM_HORIZON',
-      streamName: 'teststream',
-      table: kine.config.table,
-      cloudwatchNamespace: null,
-      cloudwatchStackname: null,
-      _leaseTimeout: 5000,
-      cloudwatch: null,
-      init: function(done) {
-        console.log('init');
-        done();
-      },
-      processRecords: function(records, done) {
-        t.equals(records.length, 1);
-        t.equals(records[0].SequenceNumber, 1);
-        done(null, true);
-        setTimeout(t.end, 10000);
-      }
-    })
-  );
-  var i = 0;
-  getRecords = kine3.kinesis.getRecords;
-  kine3.kinesis.getRecords = function(options, callback) {
-    // we mock successive responses, iterating on i in 0..5
-    if (i == 0) {
-      t.ok(true, 'gets called, return empty response (retry)');
-      callback(null, {});
-    } else if (i == 1) {
-      t.ok(true, 'gets called, return invalid response, no shard iterator (retry)');
-      callback(null, {Records: []});
-    } else if (i == 2) {
-      t.ok(true, 'gets called as well, respond with no records (retry)');
-      callback(null, {Records: null, NextShardIterator: 'valid'});
-    } else if (i == 3) {
-      t.ok(true, 'gets called, respond with an error (retry)');
-      var err = new Error('Failed parsing');
-      err.code = 'SyntaxError';
-      callback(err, null);
-    } else if (i == 4) {
-      t.ok(true, 'gets called, return valid response');
-      callback(null, {
-        NextShardIterator: 'valid',
-        Records: [
-          {SequenceNumber: 1}
-        ]
-      });
-    } else if (i == 5) {
-      t.ok(true, 'gets called, return null as next shard iterator (close shard)');
-      callback(null, {
-        NextShardIterator: null,
-        Records: []
-      });
-    }
-    i++;
-  };
-});
-
-test('stop kcl3', function(t){
-  // stop the kcl, somehow
-  kine3.kinesis.getRecords = getRecords;
-  kine3.stop();
-  setTimeout(t.end, 6000);
-});
-
 var kineManualCheckpoint;
-test('start 4th kcl', function(t) {
+test('start manual checkpoint kcl', function(t) {
   kineManualCheckpoint = Kine(
     _.extend(kinesisOptions, {
       dynamoEndpoint: 'http://localhost:4567',
@@ -267,26 +195,22 @@ test('start 4th kcl', function(t) {
       cloudwatch: null,
       init: function(done) {
         console.log('init manual checkpoint');
-        done();
+        done(null, false);
       },
       processRecords: function(records, done) {
-        done(null, true);
+        done(null, false);
         this.checkpointFunc('012345', function(){
           t.end();
         });
       }
     })
   );
-  kinesis.putRecord({ Data: 'hello', PartitionKey: 'a', StreamName: 'teststream' },
-    function(err) {
-      t.error(err);
-    });
 });
 
 test('kcl - has manually checkpointed', function(t){
   function cp() {
     dyno.query({KeyConditions:{type:{ComparisonOperator:'EQ',AttributeValueList: ['shard']}}}, function(err, response) {
-      t.equal(response.Items[0].checkpoint, '012345', 'sequenceNumber matches what we checkpointed manually');
+      t.equal(response.Items[2].checkpoint, '012345', 'sequenceNumber matches what we checkpointed manually');
       t.end();
     });
   }
@@ -298,17 +222,90 @@ test('stop kcl', function(t){
   setTimeout(t.end, 6000);
 });
 
-test('kcl - closed shard', function(t){
+var errorChecking;
+test('start getRecords errors kcl', function (t) {
+  var i = 0;
+  errorChecking = Kine(
+    _.extend(kinesisOptions, {
+      dynamoEndpoint: 'http://localhost:4567',
+      shardIteratorType: 'LATEST',
+      streamName: 'teststream',
+      table: kine.config.table,
+      cloudwatchNamespace: null,
+      cloudwatchStackname: null,
+      _leaseTimeout: 10000,
+      cloudwatch: null,
+      verbose: true,
+      maxShards: 1,
+      init: function (done) {
+        console.log('init');
+        // trigger the first getRecords call
+        kinesis.putRecord({Data: 'hello', PartitionKey: 'a', StreamName: 'teststream'}, function () {
+          done();
+        });
+      },
+      processRecords: function (records, done) {
+        var a = 0;
+        errorChecking.kinesis.getRecords = function () {
+          return {
+            on: function (action, cb) {
+              if (action === 'error') {
+                // these errors should return a timeout function with different intervals based on the error type
+                if (i === 0) {
+                  var resultError1 = cb({code: 'ServiceUnavailable'});
+                  t.equal(resultError1._idleTimeout, 2000, 'ServiceUnavailable is 2 second wait for retry');
+                }
+                if (i === 1) {
+                  var resultError2 = cb({code: 'SyntaxError'});
+                  t.equal(resultError2._idleTimeout, 500, 'ServiceUnavailable is 0.5 second wait for retry');
+                }
+                if (i === 2) {
+                  var resultError3 = cb({code: 'ProvisionedThroughputExceededException'});
+                  t.equal(resultError3._idleTimeout, 1000, 'ServiceUnavailable is 1 second wait for retry');
+                }
+                i++;
+              }
+              if (action === 'success') {
+                if(i ===1 ) {
+                  var resultError4 = cb({
+                    data: {
+                      Records: [],
+                      NextShardIterator: 'next1'
+                    }
+                  });
+                  t.equal(resultError4._idleTimeout, 2500, 'Norecords wait is 2.5 seconds');
+                }
+              }
+            },
+            abort: function () {
+              a++;
+              if (a === 5) t.end();
+            },
+            send: function () {
+            }
+          };
+        };
+        done(null, false);
+      }
+    })
+  );
+});
 
-  function closedShard() {
+test('stop error checking kcl', function(t){
+  errorChecking.stop();
+  setTimeout(t.end, 6000);
+});
+
+test('kcl - closed shard', function(t){
+  var db = DB(dyno, kinesis, {instanceId: kine.config.instanceId});
+  db.shardComplete({id: 'shardId-000000000000'}, function(){
     dyno.query({KeyConditions:{type:{ComparisonOperator:'EQ',AttributeValueList: ['shard']}}}, function(err, response) {
       var shards = response.Items;
       t.equal(shards.length, 4);
-      t.equal(shards[2].status, 'complete');
+      t.equal(shards[0].status, 'complete');
       t.end();
     });
-  }
-  setTimeout(closedShard, 1000);
+  });
 });
 
 test('teardown', util.teardown);

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -253,7 +253,7 @@ test('start getRecords errors kcl', function (t) {
                 // these errors should return a timeout function with different intervals based on the error type
                 if (i === 0) {
                   var resultError1 = cb({code: 'ServiceUnavailable'});
-                  t.equal(resultError1._idleTimeout, 2000, 'ServiceUnavailable is 2 second wait for retry');
+                  t.true(resultError1._idleTimeout > 500 && resultError1._idleTimeout < 6000, 'ServiceUnavailable is between 500ms and 6000ms for retry');
                 }
                 if (i === 1) {
                   var resultError2 = cb({code: 'SyntaxError'});

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -261,7 +261,7 @@ test('start getRecords errors kcl', function (t) {
                 }
                 if (i === 2) {
                   var resultError3 = cb({code: 'ProvisionedThroughputExceededException'});
-                  t.equal(resultError3._idleTimeout, 1000, 'ServiceUnavailable is 1 second wait for retry');
+                  t.true(resultError3._idleTimeout > 500 && resultError3._idleTimeout < 6000, 'ServiceUnavailable is between 500ms and 6000ms for retry');
                 }
                 i++;
               }


### PR DESCRIPTION
Summary of changes:

- replace `getRecords(params, callback)` with a request object that will emit events representing the lifecycle of a request (i.e. success, error, retry, extractData). Call the `send()` method manually.
- [add a timer to fire the `abort` method on the request after 5 seconds](https://github.com/mapbox/kine/blob/getRecords-refactor/lib/kcl.js#L167) if the request is hanging. This triggers a retry.
- more granular retries/delays based on the error code.
- verbose flag and addition of `fastlog` dependency for optional extra logging
- update `travis.yml` to use node `4.4.3` instead of `0.10`
- adapt tests to fit the new additions
- fix 2 typos

/cc @drboyer 