### PR TITLE
close shards when data.NextShardIterator is null and data.Records is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var Kcl = require('./lib/kcl');
  * @param {string} options.table - the dynamodb table to use for tracking shard leases.
  * @param {function} options.init - function that is called when a new lease of a shard is started
  * @param {function} options.processRecords - function is that called when new records are fetches from the kinesis shard.
+ * @param {function} [options.onShardClosed] - function that is called when a shard is closed
  * @param {string} [options.maxShards] - max number of shards to track per process. defaults to 10
  * @param {string} [options.limit] - limit used for requests to kinesis for the number of records.  This is a max, you might get few records on process records
  * @param {string} [options.maxProcessTime] - max number of millseconds between getting records before considering a process a zombie . defaults to 300000 (5mins)

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -222,17 +222,20 @@ module.exports = function(config, kinesis) {
       // only replace the iterator if we have a nextShardIterator. otherwise we'll keep using it
       if (resp.data.NextShardIterator) shard.iterator = resp.data.NextShardIterator;
       shard.lastGetRecords = +new Date();
-
       if (resp.data.Records && resp.data.Records.length > 0) {
         shard.sequenceNumber = resp.data.Records[resp.data.Records.length - 1].SequenceNumber;
         config.processRecords.call(shard, resp.data.Records, processRecordsDone);
       } else {
         // if the shard iterator is undefined (or null...) and the response is valid (not a malformed payload, with undefined Records key)
         if (!resp.data.NextShardIterator && resp.data.Records) {
-          db.shardComplete(shard, function (err) {
-            if (err) throw err;
-            console.log('Shard', shard.id, 'marked as complete');
-          });
+          if (config.onShardClosed) {
+            config.onShardClosed.call(shard, function (err) {
+              if (err) throw err;
+              markShardAsComplete(shard);
+            });
+          } else {
+            markShardAsComplete(shard);
+          }
         } else {
           // try again with the same iterator
           return setTimeout(getRecords.bind(this, shard, 0), 2500).unref();
@@ -242,6 +245,12 @@ module.exports = function(config, kinesis) {
     req.send(function () {
       clearTimeout(requestTimeOut);
     });
+
+    function markShardAsComplete(shard) {
+      db.shardComplete(shard, function (err) {
+        if (err) throw err;
+      });
+    }
 
     function processRecordsDone(err, checkpointShard) {
       if (err) throw err;

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -223,7 +223,7 @@ module.exports = function(config, kinesis) {
       if (resp.data.NextShardIterator) shard.iterator = resp.data.NextShardIterator;
       shard.lastGetRecords = +new Date();
 
-      if (resp.data.Records && resp.data.Records.length > 0 && shard.iterator) {
+      if (resp.data.Records && resp.data.Records.length > 0) {
         shard.sequenceNumber = resp.data.Records[resp.data.Records.length - 1].SequenceNumber;
         config.processRecords.call(shard, resp.data.Records, processRecordsDone);
       } else {

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -206,7 +206,10 @@ module.exports = function(config, kinesis) {
       }
     });
     req.on('success', function (resp) {
-      if (config.verbose) logger.info('[ getRecords ] success Found', resp.data.Records.length, 'items');
+      if (config.verbose) {
+        var recordLength = resp.data.Records ? resp.data.Records.length : 'n/a';
+        logger.info('[ getRecords ] success Found', recordLength, 'items');
+      }
 
       if (config.cloudwatchNamespace &&
         resp.Records &&
@@ -215,19 +218,23 @@ module.exports = function(config, kinesis) {
         throttledPutToCloudwatch('ShardIteratorAgeInMs', (+new Date()) - resp.Records[0].ApproximateArrivalTimestamp, 'Milliseconds', shard.id);
       }
 
-      // malformed responses will have an undefined NextShardIterator. In that case, we keep the existing one.
-      shard.iterator = resp.data.NextShardIterator === undefined ? shard.iterator : resp.data.NextShardIterator;
+      // malformed responses will have an undefined NextShardIterator and undefined Records key
+      // only replace the iterator if we have a nextShardIterator. otherwise we'll keep using it
+      if (resp.data.NextShardIterator) shard.iterator = resp.data.NextShardIterator;
       shard.lastGetRecords = +new Date();
 
-      if (resp.data.Records && resp.data.Records.length > 0) {
+      if (resp.data.Records && resp.data.Records.length > 0 && shard.iterator) {
         shard.sequenceNumber = resp.data.Records[resp.data.Records.length - 1].SequenceNumber;
         config.processRecords.call(shard, resp.data.Records, processRecordsDone);
       } else {
-        if (shard.iterator === null) {
+        // if the shard iterator is undefined (or null...) and the response is valid (not a malformed payload, with undefined Records key)
+        if ((!resp.data.NextShardIterator || resp.data.NextShardIterator === null) && resp.data.Records) {
           db.shardComplete(shard, function (err) {
             if (err) throw err;
+            console.log('Shard', shard.id, 'marked as complete');
           });
         } else {
+          // try again with the same iterator
           return setTimeout(getRecords.bind(this, shard, 0), 2500).unref();
         }
       }

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -228,7 +228,7 @@ module.exports = function(config, kinesis) {
         config.processRecords.call(shard, resp.data.Records, processRecordsDone);
       } else {
         // if the shard iterator is undefined (or null...) and the response is valid (not a malformed payload, with undefined Records key)
-        if ((!resp.data.NextShardIterator || resp.data.NextShardIterator === null) && resp.data.Records) {
+        if (!resp.data.NextShardIterator && resp.data.Records) {
           db.shardComplete(shard, function (err) {
             if (err) throw err;
             console.log('Shard', shard.id, 'marked as complete');

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -260,7 +260,7 @@ test('start getRecords errors kcl', function (t) {
                 }
                 if (i === 2) {
                   var resultError3 = cb({code: 'ProvisionedThroughputExceededException'});
-                  t.true(resultError3._idleTimeout > 500 && resultError3._idleTimeout < 6000, 'ServiceUnavailable is between 500ms and 6000ms for retry');
+                  t.true(resultError3._idleTimeout > 500 && resultError3._idleTimeout < 7000, 'ServiceUnavailable is between 500ms and 7000ms for retry (2nd attempt)');
                 }
                 i++;
               }

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -292,7 +292,7 @@ test('start getRecords errors kcl', function (t) {
 
 test('stop error checking kcl', function (t) {
   errorChecking.stop();
-  setTimeout(t.end, 6000);
+  setTimeout(t.end, 10000);
 });
 
 var closeShard;
@@ -316,6 +316,11 @@ test('start shard closing test', function (t) {
           done();
         });
       },
+      onShardClosed: function(done){
+        t.equal(this.id, 'shardId-000000000000', 'shard closed is the first one');
+        t.equal(this.status, 'leased', 'status is not closed yet');
+        done();
+      },
       processRecords: function (records, done) {
         closeShard.kinesis.getRecords = function () {
           return {
@@ -337,8 +342,8 @@ test('start shard closing test', function (t) {
                     }
                   }, function (err, response) {
                     var shards = response.Items;
-                    t.equal(shards.length, 4);
-                    t.equal(shards[0].status, 'complete');
+                    t.equal(shards.length, 4, 'shard count is the same');
+                    t.equal(shards[0].status, 'complete', 'shard marked as complete');
                     t.end();
                   });
                 }, 1000);


### PR DESCRIPTION
This PR updates the shard-closing logic to work using the following assumptions:

- If the response has both `data.NextShardIterator === undefined` and `data.Records === undefined`, we assume a malformed payload and try again with the same shardIterator [here](https://github.com/mapbox/kine/compare/shard-closing-fix?expand=1#diff-029298043904c6094f4dc699e832602aL231)
- If the response has `data.NextShardIterator === undefined` **or** `data.NextShardIterator === null` (which is what AWS docs stipulate) and `data.Records` is set to an empty array, the shard is done and should be closed ([here](https://github.com/mapbox/kine/compare/shard-closing-fix?expand=1#diff-029298043904c6094f4dc699e832602aR231)).

/cc @mick @drboyer @benjamintd 