### PR TITLE
add a callback for onShardClosed event

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var Kcl = require('./lib/kcl');
  * @param {string} options.table - the dynamodb table to use for tracking shard leases.
  * @param {function} options.init - function that is called when a new lease of a shard is started
  * @param {function} options.processRecords - function is that called when new records are fetches from the kinesis shard.
+ * @param {function} [options.onShardClosed] - function that is called when a shard is closed
  * @param {string} [options.maxShards] - max number of shards to track per process. defaults to 10
  * @param {string} [options.limit] - limit used for requests to kinesis for the number of records.  This is a max, you might get few records on process records
  * @param {string} [options.maxProcessTime] - max number of millseconds between getting records before considering a process a zombie . defaults to 300000 (5mins)

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -222,7 +222,6 @@ module.exports = function(config, kinesis) {
       // only replace the iterator if we have a nextShardIterator. otherwise we'll keep using it
       if (resp.data.NextShardIterator) shard.iterator = resp.data.NextShardIterator;
       shard.lastGetRecords = +new Date();
-
       if (resp.data.Records && resp.data.Records.length > 0) {
         shard.sequenceNumber = resp.data.Records[resp.data.Records.length - 1].SequenceNumber;
         config.processRecords.call(shard, resp.data.Records, processRecordsDone);
@@ -231,7 +230,8 @@ module.exports = function(config, kinesis) {
         if (!resp.data.NextShardIterator && resp.data.Records) {
           db.shardComplete(shard, function (err) {
             if (err) throw err;
-            console.log('Shard', shard.id, 'marked as complete');
+            shard.status = 'complete';
+            if (config.onShardClosed) config.onShardClosed.call(shard);
           });
         } else {
           // try again with the same iterator

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -228,11 +228,14 @@ module.exports = function(config, kinesis) {
       } else {
         // if the shard iterator is undefined (or null...) and the response is valid (not a malformed payload, with undefined Records key)
         if (!resp.data.NextShardIterator && resp.data.Records) {
-          db.shardComplete(shard, function (err) {
-            if (err) throw err;
-            shard.status = 'complete';
-            if (config.onShardClosed) config.onShardClosed.call(shard);
-          });
+          if (config.onShardClosed) {
+            config.onShardClosed.call(shard, function (err) {
+              if (err) throw err;
+              markShardAsComplete(shard);
+            });
+          } else {
+            markShardAsComplete(shard);
+          }
         } else {
           // try again with the same iterator
           return setTimeout(getRecords.bind(this, shard, 0), 2500).unref();
@@ -242,6 +245,12 @@ module.exports = function(config, kinesis) {
     req.send(function () {
       clearTimeout(requestTimeOut);
     });
+
+    function markShardAsComplete(shard) {
+      db.shardComplete(shard, function (err) {
+        if (err) throw err;
+      });
+    }
 
     function processRecordsDone(err, checkpointShard) {
       if (err) throw err;

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -316,9 +316,10 @@ test('start shard closing test', function (t) {
           done();
         });
       },
-      onShardClosed: function(){
+      onShardClosed: function(done){
         t.equal(this.id, 'shardId-000000000000', 'shard closed is the first one');
-        t.equal(this.status, 'complete', 'status is closed');
+        t.equal(this.status, 'leased', 'status is not closed yet');
+        done();
       },
       processRecords: function (records, done) {
         closeShard.kinesis.getRecords = function () {

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -292,7 +292,7 @@ test('start getRecords errors kcl', function (t) {
 
 test('stop error checking kcl', function (t) {
   errorChecking.stop();
-  setTimeout(t.end, 6000);
+  setTimeout(t.end, 10000);
 });
 
 var closeShard;
@@ -316,6 +316,10 @@ test('start shard closing test', function (t) {
           done();
         });
       },
+      onShardClosed: function(){
+        t.equal(this.id, 'shardId-000000000000', 'shard closed is the first one');
+        t.equal(this.status, 'complete', 'status is closed');
+      },
       processRecords: function (records, done) {
         closeShard.kinesis.getRecords = function () {
           return {
@@ -337,8 +341,8 @@ test('start shard closing test', function (t) {
                     }
                   }, function (err, response) {
                     var shards = response.Items;
-                    t.equal(shards.length, 4);
-                    t.equal(shards[0].status, 'complete');
+                    t.equal(shards.length, 4, 'shard count is the same');
+                    t.equal(shards[0].status, 'complete', 'shard marked as complete');
                     t.end();
                   });
                 }, 1000);


### PR DESCRIPTION
This PR adds an optional `onShardClosed` callback to allow the parent application running Kine to take action when a shard closes. We pass the entire shard object as context to that function.

Perhaps noteworthy, I'm forcing `shard.status = 'complete';` just before calling the function. Given that it's done inside the `shardComplete`'s callback, this seems like a safe assumption.

/cc @mick @drboyer @benjamintd 