### PR TITLE
only update heartbeat if shard is not complete yet

### DIFF
--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -250,6 +250,8 @@ module.exports = function(config, kinesis) {
       instanceShardList[shard.id].status = 'complete';
       db.shardComplete(shard, function (err) {
         if (err) throw err;
+        console.log('Shard marked as complete, exiting.');
+        process.exit(0);
       });
     }
 

--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -247,6 +247,7 @@ module.exports = function(config, kinesis) {
     });
 
     function markShardAsComplete(shard) {
+      instanceShardList[shard.id].status = 'complete';
       db.shardComplete(shard, function (err) {
         if (err) throw err;
       });
@@ -302,8 +303,9 @@ module.exports = function(config, kinesis) {
       if (instanceShardList[s].lastGetRecords < (+ new Date() - config.maxProcessTime)) {
         throw Error('Max processing time reached, ' + config.maxProcessTime);
       }
-
-      q.defer(db.updateLease, instanceShardList[s]);
+      if (instanceShardList[s].status !== 'complete') {
+        q.defer(db.updateLease, instanceShardList[s]);
+      }
     });
 
     q.awaitAll(function(err, resp) {

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -295,6 +295,10 @@ test('stop error checking kcl', function (t) {
   setTimeout(t.end, 10000);
 });
 
+process.exit = function(code){
+  console.log('Exited with code', code);
+};
+
 var closeShard;
 test('start shard closing test', function (t) {
   closeShard = Kine(

--- a/test/kcl.test.js
+++ b/test/kcl.test.js
@@ -295,12 +295,13 @@ test('stop error checking kcl', function (t) {
   setTimeout(t.end, 10000);
 });
 
-process.exit = function(code){
-  console.log('Exited with code', code);
-};
-
 var closeShard;
 test('start shard closing test', function (t) {
+  process.exit = function(code){
+    t.ok('has been called');
+    t.equal(code, 0, 'exited properly');
+    console.log('Exited with code', code);
+  };
   closeShard = Kine(
     _.extend(kinesisOptions, {
       dynamoEndpoint: 'http://localhost:4567',


### PR DESCRIPTION
~~In #44 we are marking shards as `complete` in dynamo, but our `heartbeat` function continues to execute on a 5-second interval. This causes a `ConditionalCheckFailedException` since there is an [expectation that the shard will be in `leased` state](https://github.com/mapbox/kine/blob/heartbeatless/lib/db.js#L152). This effectively kills the process and does not give our callback in #45 a chance to do its work. We want to let our process run for the remainder of the 5 minutes' time period to complete that work, at which point it will [run out of time](https://github.com/mapbox/kine/blob/heartbeatless/lib/kcl.js#L304) and die in the same ungraceful manner.~~

I've added the `instanceShardList[shard.id].status = 'complete';` line _before_ we mark as complete in dynamo (instead of inside the callback), otherwise there is a possible race condition that can occur where:
- our shard get closed, both `heartbeat` and `markShardAsComplete` get called at the same time
- we start the dynamo operation in `markShardAsComplete`
- at the same time, we are trying to update our lease in `updateLease` since the dynamo operation hasn't finished (but passed through the `instanceShardList[s].status !== 'complete'` statement).

This causes a `ConditionalCheckFailedException` and immediately kills the process.

The downside of this strategy is that if our `markShardAsComplete` operation fails, we are holding a shard's state as `complete`, while our dynamo table is not marked as such yet. What could happen is that process will eventually die off, another worker will pick up the shard and hopefully succeed in marking it as `completed`. I think this slower/retry situation is more desirable than the former where we can potentially lose out on data.