### PR TITLE
security vuln fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/kine",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/kine",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
         "@mapbox/dyno": "^1.6.0",
@@ -14,7 +14,7 @@
         "aws-sdk": "^2.7.3",
         "bignumber.js": "^2.4.0",
         "d3-queue": "^3.0.7",
-        "lodash": "^4.17.21"
+        "lodash": "^4.18.1"
       },
       "devDependencies": {
         "coveralls": "^3.1.1",
@@ -4164,15 +4164,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
@@ -4738,9 +4729,10 @@
       "dev": true
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
@@ -7009,16 +7001,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/request/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8048,11 +8030,16 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/uvu": {
@@ -9530,7 +9517,7 @@
         "sax": "1.2.1",
         "url": "0.10.3",
         "util": "^0.12.4",
-        "uuid": "8.0.0",
+        "uuid": "11.1.1",
         "xml2js": "0.5.0"
       }
     },
@@ -11795,15 +11782,7 @@
         "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
-        }
+        "uuid": "11.1.1"
       }
     },
     "istanbul-lib-report": {
@@ -12262,9 +12241,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -13904,15 +13883,7 @@
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        }
+        "uuid": "11.1.1"
       }
     },
     "require-directory": {
@@ -14711,9 +14682,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
     },
     "uvu": {
       "version": "0.5.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/kine",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Simple client for kinesis",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "aws-sdk": "^2.7.3",
     "bignumber.js": "^2.4.0",
     "d3-queue": "^3.0.7",
-    "lodash": "^4.17.21"
+    "lodash": "^4.18.1"
+  },
+  "overrides": {
+    "uuid": "11.1.1"
   },
   "devDependencies": {
     "coveralls": "^3.1.1",


### PR DESCRIPTION
Release Plan — @mapbox/kine v3.3.3                                                        
                                                                                            
  Change summary: Security patch — bump lodash (CVE-2026-4800) and override uuid to fix
  transitive vulnerability via aws-sdk (CVE-2026-41907). No API changes.                    
                                                                     
  ---                                                                                       
  Pre-merge                                                 
  
  See QA in https://github.com/mapbox/tourniquet/pull/138
                                                                                            
  ---                                                       
  On merge to master                     
                                                                                            
  4. Bump the package version — this is a patch release (security fix, no breaking changes):
  npm version patch   # 3.3.2 → 3.3.3                                                       
  4. This updates package.json and creates a git tag v3.3.3.                                
  5. Push the version commit and tag:                                                       
  git push origin master --tags                                                             
                                                                                            
  ---                                                                                       
  Publish to npm                                            
                                                                                            
  6. Ensure you're authenticated to the @mapbox scope:
  npm whoami                                                                                
  7. Publish:                                               
  npm publish --access public                                                               
                                                                                            
  ---                                    
  Post-publish                                                                              
                                                            
  8. Verify the published package on npm: https://www.npmjs.com/package/@mapbox/kine
  9. Update downstream consumers — bump @mapbox/kine to ^3.3.3 in any services that depend  
  on it to pick up the security fixes transitively.                                         
  10. Create a GitHub release on the v3.3.3 tag documenting the two CVEs addressed. 