### PR TITLE
Add npm OIDC release workflow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,14 @@
+name: NPM release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  npm-release:
+    uses: mapbox/gha-public/.github/workflows/workflow-npm-oidc-publish.yml@main
+    permissions:
+      id-token: write
+      contents: write
+    with:
+      create-github-release: true
+      environment: npm-release

--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,26 @@ Features:
   - checkpointing in dynamo
 
 
+#### Publishing a release
+
+Releases are published to npm via GitHub Actions using OIDC trusted publishing — no npm tokens required.
+
+**One-time setup** (already done for this repo — see [PSA doc](https://mapbox.atlassian.net/wiki/spaces/CLOUDPLAT/pages/2894397444)):
+1. The `npm-release` GitHub Environment must exist in repo settings, restricted to `master` with required reviewers.
+2. The `.github/workflows/npm-release.yml` workflow must be present.
+
+**Cutting a release:**
+1. Bump the version in `package.json` (follow semver) and update `CHANGELOG.md` if applicable.
+2. Open a PR, get it reviewed, and merge to `master`.
+3. Go to **Actions → NPM release → Run workflow**.
+4. Approve the `npm-release` environment gate when prompted.
+
+The workflow publishes to npm and creates a GitHub release automatically.
+
+Questions? Reach out in **#ask-platform** on Slack.
+
+---
+
 #### How to use
 
 See [API.md](API.md) for complete reference.


### PR DESCRIPTION
## Summary

Mapbox has migrated all public `@mapbox` packages away from npm token-based publishing to **npm OIDC Trusted Publishing via GitHub Actions** ([PSA doc](https://mapbox.atlassian.net/wiki/spaces/CLOUDPLAT/pages/2894397444)). Local `npm publish` will be deprecated by September 2026.

This PR sets up `kine` for the new approach:

- Adds `.github/workflows/npm-release.yml` — calls the `mapbox/gha-public` reusable OIDC publish workflow, gated behind the `npm-release` GitHub Environment
- Updates `Readme.md` with documented release instructions going forward

## Required: one-time repo setup before merging

Before this workflow can be triggered, the `npm-release` GitHub Environment must be created in this repo:

1. Go to **Settings → Environments → New environment**
2. Name it exactly `npm-release`
3. Under **Deployment branches**, select **Selected branches** and add `master`
4. Under **Required reviewers**, add your team or `mapbox/team-mapbox`

## Steps to release v3.3.3 using this workflow

Once this PR is merged and the environment is set up:

1. Go to **Actions → NPM release → Run workflow** (target branch: `master`)
2. Approve the `npm-release` environment gate when prompted
3. The workflow will publish `v3.3.3` to npm and create a GitHub release automatically

> Note: `v3.3.3` bumps lodash (CVE-2026-4800) and overrides uuid to fix the transitive aws-sdk vulnerability (CVE-2026-41907).

## Test plan

- [ ] `npm-release` GitHub Environment created in repo settings with correct branch restriction and reviewers
- [ ] PR merged to `master`
- [ ] Trigger **Actions → NPM release → Run workflow**
- [ ] Approve environment gate
- [ ] Confirm `3.3.3` appears on https://www.npmjs.com/package/@mapbox/kine
- [ ] Confirm GitHub release created for `v3.3.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)