### PR TITLE
Fix CI: upgrade @mapbox/fastlog to 2.0.2 (1.3.3 tarball unpublished)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@mapbox/kine",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/kine",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "license": "MIT",
       "dependencies": {
         "@mapbox/dyno": "^1.6.0",
-        "@mapbox/fastlog": "^1.3.3",
+        "@mapbox/fastlog": "^2.0.2",
         "aws-sdk": "^2.7.3",
         "bignumber.js": "^2.4.0",
         "d3-queue": "^3.0.7",
@@ -690,13 +690,14 @@
       }
     },
     "node_modules/@mapbox/fastlog": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@mapbox/fastlog/-/fastlog-1.3.3.tgz",
-      "integrity": "sha512-LhaYrzDoVP4Bt/OJmJnJyjoBiGAI/Hoy8wMoiKyPk5YEIbGn66hQnsYi1UQ5RPSR8ogaxOXm9/w2nV4DIAUqtA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/fastlog/-/fastlog-2.0.2.tgz",
+      "integrity": "sha512-TOZYsVNpWxvuAAcxrCcBoSOHI17NgflVAIN3h89iw60IiQJTl3mdHL6XcKb92glOF1ORorkOdOmzDQfrrECRFQ==",
+      "license": "MIT",
       "dependencies": {
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.8",
         "split": "^1.0.1",
-        "underscore": "^1.13.1"
+        "underscore": "^1.13.8"
       },
       "bin": {
         "fastlog": "bin/fastlog.js"
@@ -7844,9 +7845,10 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "10.1.2",
@@ -9139,13 +9141,13 @@
       }
     },
     "@mapbox/fastlog": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@mapbox/fastlog/-/fastlog-1.3.3.tgz",
-      "integrity": "sha512-LhaYrzDoVP4Bt/OJmJnJyjoBiGAI/Hoy8wMoiKyPk5YEIbGn66hQnsYi1UQ5RPSR8ogaxOXm9/w2nV4DIAUqtA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/fastlog/-/fastlog-2.0.2.tgz",
+      "integrity": "sha512-TOZYsVNpWxvuAAcxrCcBoSOHI17NgflVAIN3h89iw60IiQJTl3mdHL6XcKb92glOF1ORorkOdOmzDQfrrECRFQ==",
       "requires": {
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.8",
         "split": "^1.0.1",
-        "underscore": "^1.13.1"
+        "underscore": "^1.13.8"
       },
       "dependencies": {
         "split": {
@@ -14546,9 +14548,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="
     },
     "unified": {
       "version": "10.1.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@mapbox/dyno": "^1.6.0",
-    "@mapbox/fastlog": "^1.3.3",
+    "@mapbox/fastlog": "^2.0.2",
     "aws-sdk": "^2.7.3",
     "bignumber.js": "^2.4.0",
     "d3-queue": "^3.0.7",


### PR DESCRIPTION
## Problem

The npm release workflow fails at `npm ci` https://github.com/mapbox/kine/actions/runs/28164837487 because the `@mapbox/fastlog@1.3.3` tarball has been unpublished from the npm registry (returns 404), even though the version metadata still appears in `npm view`.

## Fix

Upgrade `@mapbox/fastlog` from `^1.3.3` → `^2.0.2` (current latest stable). The package is used in a single place (`lib/kcl.js`) as `require('@mapbox/fastlog')('kine')` — the API is unchanged between major versions.

## Why it worked locally before

`npm install` (used locally) caches downloaded tarballs in `~/.npm`. If `1.3.3` was installed before it was unpublished, the tarball was served from cache and never hit the registry. `npm ci` in CI always fetches fresh from the registry, so it hit the 404.

Tried `npm ci` with no cache
```
rm -rf node_modules && npm cache clean --force && npm ci
npm warn using --force Recommended protections disabled.
npm warn deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
npm warn deprecated queue-async@1.0.7: renamed to d3-queue
npm warn deprecated samsam@1.1.2: This package has been deprecated in favour of @sinonjs/samsam
npm warn deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
npm warn deprecated node-uuid@1.4.8: Use uuid module instead
npm warn deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm warn deprecated har-validator@5.1.5: this library is no longer supported
npm warn deprecated formatio@1.1.1: This package is unmaintained. Use @sinonjs/formatio instead

added 670 packages, and audited 671 packages in 2m

204 packages are looking for funding
  run `npm fund` for details

31 vulnerabilities (4 low, 13 moderate, 11 high, 3 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```

## Test plan

- [ ] Merge this PR to `master`
- [ ] Re-trigger **Actions → NPM release → Run workflow** to publish `v3.3.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)