### PR TITLE
Remove @mapbox/fastlog — replace with inline logger

### DIFF
--- a/lib/kcl.js
+++ b/lib/kcl.js
@@ -7,7 +7,7 @@ var AWS = require('aws-sdk');
 var DB = require('./db');
 var BN = require('bignumber.js');
 var crypto = require('crypto');
-var logger = require('@mapbox/fastlog')('kine');
+var logger = { info: function() { console.log.apply(console, ['[kine]'].concat(Array.prototype.slice.call(arguments))); } };
 
 module.exports = function(config, kinesis) {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@mapbox/dyno": "^1.6.0",
-        "@mapbox/fastlog": "^2.0.2",
         "aws-sdk": "^2.7.3",
         "bignumber.js": "^2.4.0",
         "d3-queue": "^3.0.7",
@@ -687,31 +686,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@mapbox/fastlog": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/fastlog/-/fastlog-2.0.2.tgz",
-      "integrity": "sha512-TOZYsVNpWxvuAAcxrCcBoSOHI17NgflVAIN3h89iw60IiQJTl3mdHL6XcKb92glOF1ORorkOdOmzDQfrrECRFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.8",
-        "split": "^1.0.1",
-        "underscore": "^1.13.8"
-      },
-      "bin": {
-        "fastlog": "bin/fastlog.js"
-      }
-    },
-    "node_modules/@mapbox/fastlog/node_modules/split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -9138,26 +9112,6 @@
         "parallel-stream": "^1.1.2",
         "queue-async": "~1.0.7",
         "underscore": "^1.13.1"
-      }
-    },
-    "@mapbox/fastlog": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/fastlog/-/fastlog-2.0.2.tgz",
-      "integrity": "sha512-TOZYsVNpWxvuAAcxrCcBoSOHI17NgflVAIN3h89iw60IiQJTl3mdHL6XcKb92glOF1ORorkOdOmzDQfrrECRFQ==",
-      "requires": {
-        "minimist": "^1.2.8",
-        "split": "^1.0.1",
-        "underscore": "^1.13.8"
-      },
-      "dependencies": {
-        "split": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-          "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-          "requires": {
-            "through": "2"
-          }
-        }
       }
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "license": "MIT",
   "dependencies": {
     "@mapbox/dyno": "^1.6.0",
-    "@mapbox/fastlog": "^2.0.2",
     "aws-sdk": "^2.7.3",
     "bignumber.js": "^2.4.0",
     "d3-queue": "^3.0.7",


### PR DESCRIPTION
## Problem

`@mapbox/fastlog` is private package, needs extra authentication to access in the workflow (both `1.3.3` and `2.0.2` return 404), it is causing `npm ci` to fail in the npm release workflow. https://github.com/mapbox/kine/actions/runs/28168474178/job/83426332176

consulted cloud-platform, easiest thing is to remove dependency https://mapbox.slack.com/archives/CSELS48EB/p1782459455877479

## Fix

- Remove `@mapbox/fastlog` from `dependencies` in `package.json`
- Replace the single usage in `lib/kcl.js` with a minimal inline logger:
  ```js
  var logger = { info: function() { console.log.apply(console, ['[kine]'].concat(Array.prototype.slice.call(arguments))); } };
  ```

The package was only used for `logger.info()` calls — output format is preserved with a `[kine]` prefix, matching the previous behaviour.

already tested via downstream user tourniquet 

## Test plan

- [x] Merge to `master`
- [ ] Trigger **Actions → NPM release → Run workflow** to publish `v3.3.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)