### PR TITLE
Add repository field to package.json — fix npm provenance E422

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mapbox/kine"
+    "url": "git+https://github.com/mapbox/kine.git"
   },
   "dependencies": {
     "@mapbox/dyno": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
   ],
   "author": "Mapbox",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mapbox/kine"
+  },
   "dependencies": {
     "@mapbox/dyno": "^1.6.0",
     "aws-sdk": "^2.7.3",


### PR DESCRIPTION
## Problem

The npm release workflow fails with `E422` during publish:

```
Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is "", expected to match
"https://github.com/mapbox/kine" from provenance
```

npm's OIDC trusted publishing signs a provenance statement linking the package to the GitHub Actions run. As part of verification, it checks that `repository.url` in `package.json` matches the repo the workflow ran from. The field was missing entirely.

## Fix

Add `repository` to `package.json`:

```json
"repository": {
  "type": "git",
  "url": "https://github.com/mapbox/kine"
}
```

## Next steps

- [ ] Merge this PR to `master`
- [ ] Re-trigger **Actions → NPM release → Run workflow** to publish `v3.3.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)